### PR TITLE
Refactor: Standardize Contributor Naming in Project Queries

### DIFF
--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -305,9 +305,9 @@ describe('ProjectsService', () => {
         'owner',
       );
       expect(mockQueryBuilder.leftJoin).toHaveBeenCalledWith(
-        'project_contributor',
+        'project_contributors',
         'contributor',
-        'contributor.projectId = project.id AND contributor.userId = :userId',
+        'contributor.project_id = project.id AND contributor.user_id = :userId',
         { userId },
       );
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
@@ -315,7 +315,7 @@ describe('ProjectsService', () => {
         { projectId },
       );
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        '(project.ownerId = :userId OR contributor.userId = :userId)',
+        '(project.ownerId = :userId OR contributor.user_id = :userId)',
         { userId },
       );
       expect(mockQueryBuilder.getOne).toHaveBeenCalled();
@@ -348,9 +348,9 @@ describe('ProjectsService', () => {
         'owner',
       );
       expect(mockQueryBuilder.leftJoin).toHaveBeenCalledWith(
-        'project_contributor',
+        'project_contributors',
         'contributor',
-        'contributor.projectId = project.id AND contributor.userId = :userId',
+        'contributor.project_id = project.id AND contributor.user_id = :userId',
         { userId },
       );
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
@@ -358,7 +358,7 @@ describe('ProjectsService', () => {
         { projectId },
       );
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        '(project.ownerId = :userId OR contributor.userId = :userId)',
+        '(project.ownerId = :userId OR contributor.user_id = :userId)',
         { userId },
       );
       expect(mockQueryBuilder.getOne).toHaveBeenCalled();

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -107,15 +107,18 @@ export class ProjectsService {
       .createQueryBuilder('project')
       .leftJoinAndSelect('project.owner', 'owner')
       .leftJoin(
-        'project_contributor',
+        'project_contributors',
         'contributor',
-        'contributor.projectId = project.id AND contributor.userId = :userId',
+        'contributor.project_id = project.id AND contributor.user_id = :userId',
         { userId },
       )
       .where('project.id = :projectId', { projectId: id })
-      .andWhere('(project.ownerId = :userId OR contributor.userId = :userId)', {
-        userId,
-      })
+      .andWhere(
+        '(project.ownerId = :userId OR contributor.user_id = :userId)',
+        {
+          userId,
+        },
+      )
       .getOne();
 
     if (!project) {


### PR DESCRIPTION
- Renamed references from `project_contributor` to `project_contributors` and updated field names from `projectId` and `userId` to `project_id` and `user_id` respectively in both the service and test files. This enhances consistency and clarity in our database interactions.
- Updated unit tests to reflect these changes, ensuring our tests are as sharp as our code.

Because if our naming conventions aren't consistent, are we even managing our projects effectively? Let's keep our code as tidy as our contributor relationships!