### PR TITLE
Refactor: Reverse Comment Order in Service and Tests

### DIFF
--- a/src/tasks/services/comments.service.spec.ts
+++ b/src/tasks/services/comments.service.spec.ts
@@ -191,7 +191,7 @@ describe('CommentsService', () => {
       expect(commentsRepository.find).toHaveBeenCalledWith({
         where: { taskId: 'task-1' },
         relations: ['user'],
-        order: { createdAt: 'ASC' },
+        order: { createdAt: 'DESC' },
       });
     });
 

--- a/src/tasks/services/comments.service.ts
+++ b/src/tasks/services/comments.service.ts
@@ -93,7 +93,7 @@ export class CommentsService {
     const comments = await this.commentsRepository.find({
       where: { taskId },
       relations: ['user'],
-      order: { createdAt: 'ASC' },
+      order: { createdAt: 'DESC' },
     });
 
     return comments.map((comment) => new CommentResponseDto(comment));


### PR DESCRIPTION
- Updated the `CommentsService` and its corresponding test file to change the order of comments retrieved from ascending to descending based on the `createdAt` timestamp. This adjustment ensures that the most recent comments appear first, enhancing user experience when viewing discussions.
- Adjusted unit tests to reflect this change, ensuring our tests remain aligned with the updated functionality.

Because if our comments aren't in the right order, are we even facilitating effective discussions? Let's keep our comment threads as engaging as our code!