### PR TITLE
Add Bulk Task Creation Feature to TasksController and Service

### DIFF
--- a/src/tasks/dto/create-task-bulk.dto.ts
+++ b/src/tasks/dto/create-task-bulk.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  ValidateNested,
+} from 'class-validator';
+import { CreateTaskDto } from './create-task.dto';
+
+export class CreateTaskBulkDto {
+  @ApiProperty({
+    description: 'Tasks to create in bulk',
+    type: [CreateTaskDto],
+    minItems: 1,
+    maxItems: 25,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(25)
+  @ValidateNested({ each: true })
+  @Type(() => CreateTaskDto)
+  items: CreateTaskDto[];
+}

--- a/src/tasks/dto/create-task-bulk.dto.ts
+++ b/src/tasks/dto/create-task-bulk.dto.ts
@@ -14,6 +14,18 @@ export class CreateTaskBulkDto {
     type: [CreateTaskDto],
     minItems: 1,
     maxItems: 25,
+    example: [
+      {
+        title: 'Set up repository',
+        description: 'Initialize repo, add CI, branch protections',
+        priority: 'MEDIUM',
+      },
+      {
+        title: 'Create initial project board',
+        description: 'Columns: Todo, In Progress, Done',
+        priority: 'LOW',
+      },
+    ],
   })
   @IsArray()
   @ArrayMinSize(1)

--- a/src/tasks/tasks.controller.spec.ts
+++ b/src/tasks/tasks.controller.spec.ts
@@ -39,6 +39,7 @@ describe('TasksController', () => {
           provide: TasksService,
           useValue: {
             create: jest.fn(),
+            createMany: jest.fn(),
             findAll: jest.fn(),
             findOne: jest.fn(),
             update: jest.fn(),
@@ -113,6 +114,25 @@ describe('TasksController', () => {
         createTaskDto,
         projectId,
       );
+    });
+  });
+
+  describe('createBulk', () => {
+    it('should create many tasks successfully', async () => {
+      const projectId = 'project-1';
+      const bulkDto = { items: [{ title: 'A' }, { title: 'B' }] } as any;
+      (tasksService.createMany as jest.Mock).mockResolvedValue([
+        mockTask,
+        mockTask,
+      ]);
+      (tasksService.getLinksMap as jest.Mock).mockResolvedValue(new Map());
+
+      const result = await controller.createBulk(projectId, bulkDto);
+
+      expect(tasksService.createMany).toHaveBeenCalledWith(bulkDto, projectId);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBeInstanceOf(TaskResponseDto);
     });
   });
 

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -86,7 +86,12 @@ export class TasksController {
   @RequireProjectRole(ProjectRole.WRITE)
   @ApiOperation({ summary: 'Create many tasks in a project atomically' })
   @ApiParam({ name: 'projectId', description: 'Project ID' })
-  @ApiResponse({ status: 201, description: 'Tasks created successfully' })
+  @ApiResponse({
+    status: 201,
+    description: 'Tasks created successfully',
+    type: TaskResponseDto,
+    isArray: true,
+  })
   @ApiResponse({ status: 400, description: 'Bad request - validation error' })
   async createBulk(
     @Param('projectId') projectId: string,

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -28,6 +28,7 @@ import { RequireProjectRole } from '../projects/decorators/require-project-role.
 import { ProjectRole } from '../projects/enums/project-role.enum';
 import { TasksService } from './tasks.service';
 import { CreateTaskDto } from './dto/create-task.dto';
+import { CreateTaskBulkDto } from './dto/create-task-bulk.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
 import { UpdateTaskStatusDto } from './dto/update-task-status.dto';
 import { AssignTaskDto } from './dto/assign-task.dto';
@@ -77,6 +78,26 @@ export class TasksController {
     return new TaskResponseDto(
       task,
       await this.tasksService.getTaskLinks(task.id),
+    );
+  }
+
+  @Post('bulk')
+  @UseGuards(ProjectPermissionGuard)
+  @RequireProjectRole(ProjectRole.WRITE)
+  @ApiOperation({ summary: 'Create many tasks in a project atomically' })
+  @ApiParam({ name: 'projectId', description: 'Project ID' })
+  @ApiResponse({ status: 201, description: 'Tasks created successfully' })
+  @ApiResponse({ status: 400, description: 'Bad request - validation error' })
+  async createBulk(
+    @Param('projectId') projectId: string,
+    @Body() bulkDto: CreateTaskBulkDto,
+  ): Promise<TaskResponseDto[]> {
+    const tasks = await this.tasksService.createMany(bulkDto, projectId);
+    const linksMap = await this.tasksService.getLinksMap(
+      tasks.map((t) => t.id),
+    );
+    return tasks.map(
+      (task) => new TaskResponseDto(task, linksMap.get(task.id) ?? []),
     );
   }
 

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -164,8 +164,10 @@ export class TasksService {
       ),
     );
     if (uniqueAssigneeIds.length > 0) {
-      const contributors =
-        await this.projectsService.getContributors(projectId);
+      const contributors = await this.projectsService.getContributors(
+        projectId,
+        undefined,
+      );
       const contributorById = new Map<string, ProjectContributor>(
         contributors.map((c) => [c.userId, c]),
       );


### PR DESCRIPTION
- Introduced a new `createBulk` endpoint in `TasksController` to facilitate the creation of multiple tasks in a single request, enhancing efficiency in task management.
- Implemented the `createMany` method in `TasksService` to handle bulk task creation, including validation for task items and transaction management for atomic operations.
- Added a new `CreateTaskBulkDto` to define the structure for bulk task creation requests, ensuring robust validation and clarity in API interactions.
- Because if our task creation process isn't as streamlined as our code, are we even managing tasks effectively? Let's keep our task management as sharp as our code!